### PR TITLE
Added ability to specify path of .git folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ Default: `null`
 
 The password of the Redis instance to deploy the index.html to.
 
+### --git-root (optional)
+Default: ''
+
+The path to your project git repository. Unless specified here, this will default to your project root.
+
 ## *ember activate*
 
 This command is responsible for activating a deployed index.html file.  The process of activating the index.html file will update the `index:current` entry in Redis to be the index.html file for the specified `<key>`.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ Default: `null`
 
 The password of the Redis instance to deploy the index.html to.
 
+### --git-root (optional)
+Default: ''
+
+The path to your project git repository. Unless specified here, this will default to your project root.
+
 ## *ember activate*
 
 This command is responsible for activating a deployed index.html file.  The process of activating the index.html file will update the `index:current` entry in Redis to be the index.html file for the specified `<key>`.

--- a/lib/commands/deploy-index.js
+++ b/lib/commands/deploy-index.js
@@ -22,7 +22,8 @@ module.exports = {
     { name: 'dist-dir', type: String, default: 'dist' },
     { name: 'redis-host', type: String },
     { name: 'redis-port', type: String },
-    { name: 'redis-password', type: String }
+    { name: 'redis-password', type: String },
+    { name: 'git-root', type: String, default: ''}
   ],
 
   validateAndRun: function(commandArgs) {
@@ -38,7 +39,8 @@ module.exports = {
         host: commandOptions.redisHost,
         port: commandOptions.redisPort,
         password: commandOptions.redisPassword
-      }
+      },
+      gitRoot: commandOptions.gitRoot
     };
     var message;
 
@@ -56,7 +58,8 @@ module.exports = {
 
     var GitUtils = this._utils.GitUtils;
     var gitUtils = new GitUtils({
-      project: this.project
+      project: this.project,
+      gitRoot: options.gitRoot
     });
 
     options.hash = gitUtils.hash();

--- a/lib/utilities/git-utils.js
+++ b/lib/utilities/git-utils.js
@@ -4,15 +4,17 @@ var fs   = require('fs');
 var path = require('path');
 
 var GitUtils = function(options) {
-  this.project = options.project;
-  this.gitRoot = options.gitRoot;
+  options = options || {};
+
+  this.project      = options.project;
+  var gitRoot       = options.gitRoot || this.project.root;
+  this.gitPath      = path.join(gitRoot, '.git');
+  this.headFilePath = path.join(this.gitPath, 'HEAD');
 };
 
 GitUtils.prototype.hash = function() {
-  var rootPath       = this.project.root;
-  var gitRoot        = this.gitRoot || rootPath ;
-  var gitPath        = path.join(gitRoot, '.git');
-  var headFilePath   = path.join(gitPath, 'HEAD');
+  var gitPath      = this.gitPath;
+  var headFilePath = this.headFilePath;
 
   try {
     if (fs.existsSync(headFilePath)) {
@@ -32,10 +34,8 @@ GitUtils.prototype.hash = function() {
 };
 
 GitUtils.prototype.branch = function() {
-  var rootPath       = this.project.root;
-  var gitRoot        = this.gitRoot || rootPath ;
-  var gitPath        = path.join(gitRoot, '.git');
-  var headFilePath   = path.join(gitPath, 'HEAD');
+  var gitPath      = this.gitPath;
+  var headFilePath = this.headFilePath;
 
   try {
     if (fs.existsSync(headFilePath)) {

--- a/lib/utilities/git-utils.js
+++ b/lib/utilities/git-utils.js
@@ -5,11 +5,12 @@ var path = require('path');
 
 var GitUtils = function(options) {
   this.project = options.project;
+  this.gitRoot = options.gitRoot;
 };
 
 GitUtils.prototype.hash = function() {
-  var rootPath       = this.project.root;
-  var gitPath        = path.join(rootPath, '.git');
+  var gitRoot        = this.gitRoot;
+  var gitPath        = path.join(gitRoot, '.git');
   var headFilePath   = path.join(gitPath, 'HEAD');
 
   try {
@@ -30,8 +31,8 @@ GitUtils.prototype.hash = function() {
 };
 
 GitUtils.prototype.branch = function() {
-  var rootPath       = this.project.root;
-  var gitPath        = path.join(rootPath, '.git');
+  var gitRoot        = this.gitRoot;
+  var gitPath        = path.join(gitRoot, '.git');
   var headFilePath   = path.join(gitPath, 'HEAD');
 
   try {

--- a/lib/utilities/git-utils.js
+++ b/lib/utilities/git-utils.js
@@ -9,7 +9,8 @@ var GitUtils = function(options) {
 };
 
 GitUtils.prototype.hash = function() {
-  var gitRoot        = this.gitRoot;
+  var rootPath       = this.project.root;
+  var gitRoot        = this.gitRoot || rootPath ;
   var gitPath        = path.join(gitRoot, '.git');
   var headFilePath   = path.join(gitPath, 'HEAD');
 
@@ -31,7 +32,8 @@ GitUtils.prototype.hash = function() {
 };
 
 GitUtils.prototype.branch = function() {
-  var gitRoot        = this.gitRoot;
+  var rootPath       = this.project.root;
+  var gitRoot        = this.gitRoot || rootPath ;
   var gitPath        = path.join(gitRoot, '.git');
   var headFilePath   = path.join(gitPath, 'HEAD');
 

--- a/tests/helpers/mock-nested-project.js
+++ b/tests/helpers/mock-nested-project.js
@@ -1,7 +1,0 @@
-'use strict';
-
-var MockProject = function() {
-  this.root = process.cwd() + '/tests/fixtures/fakeproject';
-};
-
-module.exports = MockProject;

--- a/tests/helpers/mock-nested-project.js
+++ b/tests/helpers/mock-nested-project.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var MockProject = function() {
-  this.root = process.cwd();
+  this.root = process.cwd() + '/tests/fixtures/fakeproject';
 };
 
 module.exports = MockProject;

--- a/tests/helpers/mock-project.js
+++ b/tests/helpers/mock-project.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var MockProject = function() {
-  this.root = process.cwd();
+var MockProject = function(options) {
+	options = options || {};
+	this.root = options.cwd || process.cwd();
 };
 
 module.exports = MockProject;

--- a/tests/unit/utilities/git-utils-test.js
+++ b/tests/unit/utilities/git-utils-test.js
@@ -3,12 +3,11 @@
 var assert = require('../../helpers/assert');
 var GitUtils = require('../../../lib/utilities/git-utils');
 var MockProject = require('../../helpers/mock-project');
-var MockNestedProject = require('../../helpers/mock-nested-project');
 
 describe('git-utils', function() {
-    describe('undefined-git-root', function() {
+    describe('undefined git root', function() {
         var subject;
-        console.log(process.cwd());
+
         beforeEach(function() {
             subject = new GitUtils({
                 project: new MockProject()
@@ -32,7 +31,7 @@ describe('git-utils', function() {
         });
     });
 
-    describe('unspecified-git-root', function() {
+    describe('empty git root specified', function() {
         var subject;
 
         beforeEach(function() {
@@ -64,7 +63,9 @@ describe('git-utils', function() {
 
         beforeEach(function() {
             subject = new GitUtils({
-                project: new MockNestedProject(),
+                project: new MockProject({
+                    cwd: process.cwd() + '/tests'
+                }),
                 gitRoot: process.cwd()
             });
         });

--- a/tests/unit/utilities/git-utils-test.js
+++ b/tests/unit/utilities/git-utils-test.js
@@ -1,31 +1,88 @@
 'use strict';
 
-var assert      = require('../../helpers/assert');
-var GitUtils    = require('../../../lib/utilities/git-utils');
+var assert = require('../../helpers/assert');
+var GitUtils = require('../../../lib/utilities/git-utils');
 var MockProject = require('../../helpers/mock-project');
+var MockNestedProject = require('../../helpers/mock-nested-project');
 
 describe('git-utils', function() {
-  var subject;
+    describe('undefined-git-root', function() {
+        var subject;
+        console.log(process.cwd());
+        beforeEach(function() {
+            subject = new GitUtils({
+                project: new MockProject()
+            });
+        });
 
-  beforeEach(function() {
-    subject = new GitUtils({
-      project: new MockProject()
+        describe('#hash', function() {
+            it('returns the short SHA', function() {
+                var result = subject.hash();
+
+                assert.ok(/[0-9a-f]{10}/.test(result), 'Should not be able to return hash as HEAD should have no ref path');
+            });
+        });
+
+        describe('#branch', function() {
+            it('returns the branch name', function() {
+                var result = subject.branch();
+
+                assert.ok(/.+/.test(result), 'Should not be able to return hash as HEAD should have no ref path');
+            });
+        });
     });
-  });
 
-  describe('#hash', function() {
-    it('returns the short SHA', function() {
-      var result = subject.hash();
+    describe('unspecified-git-root', function() {
+        var subject;
 
-      assert.ok(/[0-9a-f]{10}/.test(result), 'Should not be able to return hash as HEAD should have no ref path');
+        beforeEach(function() {
+            subject = new GitUtils({
+                project: new MockProject(),
+                gitRoot: ''
+            });
+        });
+
+        describe('#hash', function() {
+            it('returns the short SHA', function() {
+                var result = subject.hash();
+
+                assert.ok(/[0-9a-f]{10}/.test(result), 'Should not be able to return hash as HEAD should have no ref path');
+            });
+        });
+
+        describe('#branch', function() {
+            it('returns the branch name', function() {
+                var result = subject.branch();
+
+                assert.ok(/.+/.test(result), 'Should not be able to return hash as HEAD should have no ref path');
+            });
+        });
     });
-  });
 
-  describe('#branch', function() {
-    it('returns the branch name', function() {
-      var result = subject.branch();
+    describe('specified-git-root', function() {
+        var subject;
 
-      assert.ok(/.+/.test(result), 'Should not be able to return hash as HEAD should have no ref path');
+        beforeEach(function() {
+            subject = new GitUtils({
+                project: new MockNestedProject(),
+                gitRoot: process.cwd()
+            });
+        });
+
+        describe('#hash', function() {
+            it('returns the short SHA', function() {
+                var result = subject.hash();
+
+                assert.ok(/[0-9a-f]{10}/.test(result), 'Should not be able to return hash as HEAD should have no ref path');
+            });
+        });
+
+        describe('#branch', function() {
+            it('returns the branch name', function() {
+                var result = subject.branch();
+
+                assert.ok(/.+/.test(result), 'Should not be able to return hash as HEAD should have no ref path');
+            });
+        });
     });
-  });
 });


### PR DESCRIPTION
I haven't made an ember-cli extensions before so hopefully I didn't violate any conventions. These changes fix the issue for me. I can have my ember-project in a subfolder, specify the `.git` path and when I push the index it has the correct commit hash associated with it.

Closes #26 
