### PR TITLE
Improve how we retrieve the git hash and branch

### DIFF
--- a/lib/commands/deploy-index.js
+++ b/lib/commands/deploy-index.js
@@ -39,8 +39,7 @@ module.exports = {
         host: commandOptions.redisHost,
         port: commandOptions.redisPort,
         password: commandOptions.redisPassword
-      },
-      gitRoot: commandOptions.gitRoot
+      }
     };
     var message;
 
@@ -58,11 +57,8 @@ module.exports = {
 
     var GitUtils = this._utils.GitUtils;
     var gitUtils = new GitUtils({
-      project: this.project,
-      gitRoot: options.gitRoot
+      project: this.project
     });
-
-    options.hash = gitUtils.hash();
 
     var DeployIndexTask = this._tasks.DeployIndexTask;
     var deployIndexTask = new DeployIndexTask({
@@ -70,6 +66,12 @@ module.exports = {
       project: this.project
     });
 
+    return gitUtils.hash()
+      .then(function(hash) {
+        options.hash = hash;
+
+        return deployIndexTask.run(options);
+      });
     return deployIndexTask.run(options);
   },
 

--- a/lib/utilities/git-utils.js
+++ b/lib/utilities/git-utils.js
@@ -1,56 +1,39 @@
 'use strict';
 
-var fs   = require('fs');
-var path = require('path');
+var exec        = require('exec');
+var Promise     = require('../ext/promise');
+var SilentError = require('../errors/silent');
 
 var GitUtils = function(options) {
-  options = options || {};
-
-  this.project      = options.project;
-  var gitRoot       = options.gitRoot || this.project.root;
-  this.gitPath      = path.join(gitRoot, '.git');
-  this.headFilePath = path.join(this.gitPath, 'HEAD');
+  this.project = options.project;
 };
 
 GitUtils.prototype.hash = function() {
-  var gitPath      = this.gitPath;
-  var headFilePath = this.headFilePath;
+  var root = this.project.root;
 
-  try {
-    if (fs.existsSync(headFilePath)) {
-      var branchSHA;
-      var headFile = fs.readFileSync(headFilePath, {encoding: 'utf8'});
-      var refPath = headFile.split(' ')[1];
-
-      if (refPath) {
-        var branchPath = path.join(gitPath, refPath.trim());
-        branchSHA  = fs.readFileSync(branchPath);
-        return branchSHA.toString().slice(0, 10);
+  return new Promise(function(resolve, reject) {
+    exec('git rev-parse --short=10 HEAD', { cwd: root }, function(error, out, code) {
+      if (error) {
+        reject(new SilientError(error));
       }
-    }
-  } catch (err) {
-    console.error(err.stack);
-  }
+
+      resolve(out);
+    });
+  });
 };
 
 GitUtils.prototype.branch = function() {
-  var gitPath      = this.gitPath;
-  var headFilePath = this.headFilePath;
+  var root = this.project.root;
 
-  try {
-    if (fs.existsSync(headFilePath)) {
-      var headFile = fs.readFileSync(headFilePath, {encoding: 'utf8'});
-      var parts = headFile.split('/');
-
-      if (parts.length > 1) {
-        var branchName = parts.slice(-1)[0].trim();
-
-        return branchName;
+  return new Promise(function(resolve, reject) {
+    exec('git rev-parse --abbrev-ref HEAD', { cwd: root }, function(error, out, code) {
+      if (error) {
+        reject(new SilientError(error));
       }
-    }
-  } catch (err) {
-    console.error(err.stack);
-  }
+
+      resolve(out);
+    });
+  });
 };
 
 module.exports = GitUtils;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "aws-sdk": "^2.0.17",
     "chalk": "^0.5.1",
+    "exec": "^0.1.2",
     "mime": "^1.2.11",
     "node-env-file": "^0.1.3",
     "nopt": "^3.0.1",

--- a/tests/unit/utilities/git-utils-test.js
+++ b/tests/unit/utilities/git-utils-test.js
@@ -5,85 +5,33 @@ var GitUtils = require('../../../lib/utilities/git-utils');
 var MockProject = require('../../helpers/mock-project');
 
 describe('git-utils', function() {
-    describe('undefined git root', function() {
-        var subject;
+  var subject;
 
-        beforeEach(function() {
-            subject = new GitUtils({
-                project: new MockProject()
-            });
-        });
+  beforeEach(function() {
+    subject = new GitUtils({
+      project: new MockProject()
+    });
+  });
 
-        describe('#hash', function() {
-            it('returns the short SHA', function() {
-                var result = subject.hash();
-
-                assert.ok(/[0-9a-f]{10}/.test(result), 'Should not be able to return hash as HEAD should have no ref path');
-            });
-        });
-
-        describe('#branch', function() {
-            it('returns the branch name', function() {
-                var result = subject.branch();
-
-                assert.ok(/.+/.test(result), 'Should not be able to return hash as HEAD should have no ref path');
-            });
+  describe('#hash', function() {
+    it('returns the short SHA', function() {
+      return subject.hash()
+        .then(function(hash) {
+          assert.ok(/[0-9a-f]{10}/.test(hash), 'Should return hash');
+        }, function() {
+          assert.ok(false, 'Should have returned hash');
         });
     });
+  });
 
-    describe('empty git root specified', function() {
-        var subject;
-
-        beforeEach(function() {
-            subject = new GitUtils({
-                project: new MockProject(),
-                gitRoot: ''
-            });
-        });
-
-        describe('#hash', function() {
-            it('returns the short SHA', function() {
-                var result = subject.hash();
-
-                assert.ok(/[0-9a-f]{10}/.test(result), 'Should not be able to return hash as HEAD should have no ref path');
-            });
-        });
-
-        describe('#branch', function() {
-            it('returns the branch name', function() {
-                var result = subject.branch();
-
-                assert.ok(/.+/.test(result), 'Should not be able to return hash as HEAD should have no ref path');
-            });
+  describe('#branch', function() {
+    it('returns the branch name', function() {
+      return subject.branch()
+        .then(function(branch) {
+          assert.ok(/.*/.test(branch), 'Should return branch');
+        }, function() {
+          assert.ok(false, 'Should have returned branch');
         });
     });
-
-    describe('specified-git-root', function() {
-        var subject;
-
-        beforeEach(function() {
-            subject = new GitUtils({
-                project: new MockProject({
-                    cwd: process.cwd() + '/tests'
-                }),
-                gitRoot: process.cwd()
-            });
-        });
-
-        describe('#hash', function() {
-            it('returns the short SHA', function() {
-                var result = subject.hash();
-
-                assert.ok(/[0-9a-f]{10}/.test(result), 'Should not be able to return hash as HEAD should have no ref path');
-            });
-        });
-
-        describe('#branch', function() {
-            it('returns the branch name', function() {
-                var result = subject.branch();
-
-                assert.ok(/.+/.test(result), 'Should not be able to return hash as HEAD should have no ref path');
-            });
-        });
-    });
+  });
 });


### PR DESCRIPTION
Instead of inspecting the .git directory, we are now calling a git command to get the hash and branch.  This means that the ember app can be a sub directory of a git repo instead of having to be the root of the git repo.  Also means we can remove the gitRoot config property.

Makes #30 redundant.
