### PR TITLE
exec(git...) does not work in windows

### DIFF
--- a/lib/utilities/git-utils.js
+++ b/lib/utilities/git-utils.js
@@ -17,6 +17,9 @@ GitUtils.prototype.hash = function () {
 
     return new Promise(function (resolve, reject) {
         if (isWin) {
+            git.stdout.on('data', function(data){
+                resolve(data.toString().replace(/\n/g, '').trim());
+            })
         } else {
             exec('git rev-parse --short=10 HEAD', {cwd: root}, function (error, out, code) {
                 if (error) {

--- a/lib/utilities/git-utils.js
+++ b/lib/utilities/git-utils.js
@@ -1,39 +1,54 @@
 'use strict';
 
-var exec        = require('exec');
-var Promise     = require('../ext/promise');
+var exec = require('exec');
+var Promise = require('../ext/promise');
 var SilentError = require('../errors/silent');
 
-var GitUtils = function(options) {
-  this.project = options.project;
+var spawn = require('child_process').spawn;
+var git = spawn('git', ['rev-parse', '--short=10', 'HEAD'], {cwd: root});
+var isWin = /^win/.test(process.platform);
+
+var GitUtils = function (options) {
+    this.project = options.project;
 };
 
-GitUtils.prototype.hash = function() {
-  var root = this.project.root;
+GitUtils.prototype.hash = function () {
+    var root = this.project.root;
 
-  return new Promise(function(resolve, reject) {
-    exec('git rev-parse --short=10 HEAD', { cwd: root }, function(error, out, code) {
-      if (error) {
-        reject(new SilientError(error));
-      }
+    return new Promise(function (resolve, reject) {
+        if (isWin) {
+        } else {
+            exec('git rev-parse --short=10 HEAD', {cwd: root}, function (error, out, code) {
+                if (error) {
+                    reject(new SilientError(error));
+                }
 
-      resolve(out.trim());
+                resolve(out.trim());
+            });
+
+        }
     });
-  });
 };
 
-GitUtils.prototype.branch = function() {
-  var root = this.project.root;
+GitUtils.prototype.branch = function () {
+    var root = this.project.root;
 
-  return new Promise(function(resolve, reject) {
-    exec('git rev-parse --abbrev-ref HEAD', { cwd: root }, function(error, out, code) {
-      if (error) {
-        reject(new SilientError(error));
-      }
+    return new Promise(function (resolve, reject) {
+        if (isWin) {
+            git.stdout.on('data', function(data){
+                resolve(data.toString().replace(/\n/g, '').trim());
+            })
+        }else{
+            exec('git rev-parse --abbrev-ref HEAD', {cwd: root}, function (error, out, code) {
+                if (error) {
+                    reject(new SilientError(error));
+                }
 
-      resolve(out.trim());
+                resolve(out.trim());
+            });
+
+        }
     });
-  });
 };
 
 module.exports = GitUtils;


### PR DESCRIPTION
@achambers 

Thanks for putting this package together.  So, basically the issue here is that you cannot do a git command with the exec() function.  For some reason it errors out.  So instead what works is using the child_process.spawn function.

I don't catch errors for now, but we should merge this in and if someone has a good way to catch the error that would be awesome.
