### PR TITLE
Display the environment flag in the activate command for non-default environments.

### DIFF
--- a/lib/commands/deploy-index.js
+++ b/lib/commands/deploy-index.js
@@ -30,6 +30,8 @@ module.exports = {
       project: this.project
     });
 
+    this.environment = commandOptions.environment;
+
     var DeployIndexTask = this._tasks.DeployIndexTask;
     var deployIndexTask = new DeployIndexTask({
       ui: this.ui,

--- a/lib/tasks/deploy-index.js
+++ b/lib/tasks/deploy-index.js
@@ -8,6 +8,8 @@ var SilentError = require('../errors/silent');
 var DeployIndexTask = function(options) {
   this.project = options.project;
   this.ui = options.ui;
+  this.environment = options.environment;
+  this.availableOptions = options.availableOptions;
 };
 
 DeployIndexTask.prototype.run = function(config) {
@@ -33,6 +35,18 @@ DeployIndexTask.prototype.run = function(config) {
   }
 
   var data = fs.readFileSync(indexFilePath);
+  var environment = this.environment;
+  var availableOptions = this.availableOptions;
+  var numOptions = availableOptions.length;
+  var defaultEnvironment = null;
+
+  while(numOptions--) {
+    var option = availableOptions[numOptions];
+    if(option.name == 'environment') {
+      defaultEnvironment = option.default;
+      break;
+    }
+  }
 
   return new Promise(function(resolve, reject) {
     var client = require('redis').createClient(redisPort, redisHost, {
@@ -54,7 +68,13 @@ DeployIndexTask.prototype.run = function(config) {
       } else {
         ui.write(chalk.green('\nSuccessfully deployed to Redis: ' + indexFilePath));
         ui.write(chalk.bold.gray('\n\nTo activate index.html:'));
-        ui.write(chalk.gray('\nember activate ' + hash + '\n\n'));
+
+        var activateMsg = '\nember activate ' + hash;
+
+        if(environment != defaultEnvironment) {
+          activateMsg += ' --environment=' + environment;
+        }
+        ui.write(chalk.gray(activateMsg + '\n\n'));
 
         return resolve();
       }

--- a/tests/unit/tasks/deploy-index-test.js
+++ b/tests/unit/tasks/deploy-index-test.js
@@ -20,7 +20,11 @@ describe('deploy-index task', function() {
 
     subject = new Task({
       project: new MockProject(),
-      ui: mockUI
+      ui: mockUI,
+      environment: 'development',
+      availableOptions: [
+        { name: 'environment', type: String, default: 'development' }
+      ]
     });
 
     taskOptions = {
@@ -84,6 +88,29 @@ describe('deploy-index task', function() {
       assert.include(mockUI.output[0], 'Successfully deployed to Redis: tests/fixtures/dist/index.html');
       assert.include(mockUI.output[1], 'To activate index.html:');
       assert.include(mockUI.output[2], 'ember activate 123456');
+      assert.notInclude(mockUI.output[2], '--environment=development');
+    })
+    .catch(function(error) {
+      assert.ok(false, 'Shouldn\'t have thrown an error');
+    });
+  });
+
+  it('includes the environment flag if not executing in the default environment', function() {
+    redis.throwSetError(false);
+
+    var productionTask = new Task({
+      project: new MockProject(),
+      ui: mockUI,
+      environment: 'production',
+      availableOptions: [
+        { name: 'environment', type: String, default: 'development' }
+      ]
+    });
+
+    return productionTask.run(taskOptions).then(function() {
+      assert.include(mockUI.output[0], 'Successfully deployed to Redis: tests/fixtures/dist/index.html');
+      assert.include(mockUI.output[1], 'To activate index.html:');
+      assert.include(mockUI.output[2], 'ember activate 123456 --environment=production');
     })
     .catch(function(error) {
       assert.ok(false, 'Shouldn\'t have thrown an error');


### PR DESCRIPTION
Regardless of what environment you `deploy:index` to, you'll see an activate command that assumes the default environment.

```
$ ember deploy:index --environment=production
version: 0.1.2
Connected to Redis [greeneye.redistogo.com:9585]

Successfully deployed to Redis: dist/index.html

To activate index.html:
ember activate 8f057b1519
```

If I just blindly run this command it fails.

```
$ ember activate 8f057b1519
version: 0.1.2
The `ember activate` command requires index config to be set.  For more details see http://github.com/achambers/ember-cli-deploy
```

There's room for improvement in the error message, but it's telling you that `config/deploy/development.js` doesn't exist.

My changes add the `--environment` flag to the activate command when not running in the default environment.

```
$ ember deploy:index --environment=production
version: 0.1.2
Connected to Redis [greeneye.redistogo.com:9585]

Successfully deployed to Redis: dist/index.html

To activate index.html:
ember activate 8f057b1519 --environment=production
```
