### PR TITLE
Implemented support for session tokens

### DIFF
--- a/lib/tasks/deploy-assets.js
+++ b/lib/tasks/deploy-assets.js
@@ -18,6 +18,7 @@ DeployAssetsTask.prototype.run = function(config) {
   var ui                = this.ui;
   var s3AccessKeyId     = config.assets.accessKeyId;
   var s3SecretAccessKey = config.assets.secretAccessKey;
+  var s3SessionToken    = config.assets.sessionToken;
   var s3Bucket          = config.assets.bucket;
   var s3Region          = config.assets.region;
   var filePattern       = config.assets.filePattern;
@@ -42,6 +43,7 @@ DeployAssetsTask.prototype.run = function(config) {
   var uploader = new S3Uploader({
     accessKeyId: s3AccessKeyId,
     secretAccessKey: s3SecretAccessKey,
+    sessionToken: s3SessionToken,
     region: s3Region,
     bucket: s3Bucket
   });

--- a/lib/utilities/s3-uploader.js
+++ b/lib/utilities/s3-uploader.js
@@ -17,6 +17,7 @@ function S3Uploader(options) {
     this.client = new AWS.S3({
       accessKeyId: options.accessKeyId,
       secretAccessKey: options.secretAccessKey,
+      sessionToken: options.sessionToken,
       region: options.region
     });
   }

--- a/lib/validators/assets-config.js
+++ b/lib/validators/assets-config.js
@@ -13,7 +13,7 @@ function AssetsConfigValidator(options) {
 AssetsConfigValidator.prototype.validate = function(config) {
   config = config || {};
 
-  var assetsConfig         = config.assets;
+  var assetsConfig = config.assets;
   var defaultAssetsConfig = {
     region: 'us-east-1',
     filePattern: '**/*.{js,css,png,gif,jpg}'

--- a/tests/unit/tasks/deploy-assets-test.js
+++ b/tests/unit/tasks/deploy-assets-test.js
@@ -26,6 +26,7 @@ describe('deploy-assets task', function() {
       assets: {
         accessKeyId: 'access-key',
         secretAccessKey: 'access-secret',
+        sessionToken: 'session-token',
         region: 'region',
         bucket: 'bucket',
         filePattern: '**/*.{js,css,png,gif,jpg}'
@@ -59,6 +60,7 @@ describe('deploy-assets task', function() {
 
       assert.equal(params.accessKeyId, 'access-key');
       assert.equal(params.secretAccessKey, 'access-secret');
+      assert.equal(params.sessionToken, 'session-token');
       assert.equal(params.region, 'region');
       assert.equal(params.bucket, 'bucket');
 


### PR DESCRIPTION
This PR adds support for session tokens, an additional authentication requirement for AWS credentials generated using AWS STS.
